### PR TITLE
Add headers for outgoing emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,23 @@
 WSB Site
+========
+
+How to run application for development with Windows
+--------
+**Install Apache**
+1. Download Apache. Apache 2.4.29 Win64.
+2. Add Apache bin to path.
+  
+**Install and configure PHP**
+1. Download PHP. PHP 7.2 (7.2.3) VC15 x64 Thread Safe
+2. Add to path
+3. Configure Apahace for PHP, httpd.conf
+    * LoadModule php7_module "C:\php\php7apache2_4.dll"
+	* AddHandler application/x-httpd-php .php
+	* PHPIniDir “C:/php”
+
+**Install and configure a mail server**
+1. For development purposes, a [dummy SMTP server](https://archive.codeplex.com/?p=smtp4dev) was used
+
+**Run application as console application**  
+1. Run the httpd command 
+

--- a/WSB Send Mail.php
+++ b/WSB Send Mail.php
@@ -20,6 +20,8 @@ If you add a form field, you will need to add it here.
 $email_address = $_REQUEST['email_address'] ;
 $comments = $_REQUEST['comments'] ;
 $first_name = $_REQUEST['first_name'] ;
+$headers = 'From: System_Admin' . "\r\n";
+$headers .= 'Return-Path: ' . $email_address . "\r\n";
 $msg = 
 "First Name: " . $first_name . "\r\n" . 
 "Email: " . $email_address . "\r\n" . 
@@ -69,7 +71,7 @@ header( "Location: $error_page" );
 // If we passed all previous tests, send the email then redirect to the thank you page.
 else {
 
-	mail( "$webmaster_email", "Availablity", $msg );
+	mail( "$webmaster_email", "Availablity", $msg, $headers);
 
 	header( "Location: $thankyou_page" );
 }


### PR DESCRIPTION
* Updated WSB Send Mail.php to use from and return-path header with outgoing email

@geodrummer I had to add headers to make the email call work for me. My PHP server kept on complaining that you did not have those headers. The headers might help with the issues you were having. I will try to put this on a ec2 instance tomorrow. 